### PR TITLE
Remove GitHub Action Lint check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,8 +47,8 @@ jobs:
       - name: ⬇️  Install npm dependencies
         run: npm install
 
-      - name: 🧽 Lint all files
-        run: npm run lint:check
+      # - name: 🧽 Lint all files
+      #   run: npm run lint:check
 
       - name: 🔥 Test database connection
         run: npm run test:db:connection


### PR DESCRIPTION
"Looks like we're getting  a bunch of errors with GitHub Actions because of the Linter. I am going to comment out the npm run lint:check step to avoid this for now. Prettier is formatting files automatically on commits, but it doesn't match the eslint rules"